### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/scripts/meta-tags.js
+++ b/scripts/meta-tags.js
@@ -112,13 +112,21 @@ class MetaTagManager {
      */
     getEnvironmentType() {
         const hostname = window.location.hostname;
+        const allowedHostnames = [
+            'localhost',
+            '127.0.0.1',
+            'azurestaticapps.net',
+            'preview.azurestaticapps.net'
+        ];
         
-        if (hostname.includes('localhost') || hostname.includes('127.0.0.1')) {
-            return 'development';
-        } else if (hostname.includes('-') && hostname.includes('azurestaticapps.net')) {
-            return 'preview';
-        } else if (hostname.includes('azurestaticapps.net')) {
-            return 'production';
+        if (allowedHostnames.includes(hostname)) {
+            if (hostname === 'localhost' || hostname === '127.0.0.1') {
+                return 'development';
+            } else if (hostname === 'preview.azurestaticapps.net') {
+                return 'preview';
+            } else if (hostname === 'azurestaticapps.net') {
+                return 'production';
+            }
         }
         
         return 'unknown';


### PR DESCRIPTION
Potential fix for [https://github.com/Pace-Applied-Solutions/PacePublicShare/security/code-scanning/5](https://github.com/Pace-Applied-Solutions/PacePublicShare/security/code-scanning/5)

The best way to fix the problem is to parse the hostname properly and validate it against an explicit whitelist of allowed domains. This ensures that only valid hostnames are considered, preventing arbitrary hosts from passing the check.

**Steps to fix the issue:**
1. Use the `URL` API to parse the hostname of the current environment dynamically.
2. Replace the substring checks with a comparison against a whitelist of allowed hostnames (e.g., `'azurestaticapps.net'`, `'preview.azurestaticapps.net'`, etc.).

**Required changes:**
- Add a whitelist of allowed hostnames.
- Update the logic in the `getEnvironmentType` method to use the whitelist for validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
