### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/azure-static-web-apps-white-mud-0cad69810.yml
+++ b/.github/workflows/azure-static-web-apps-white-mud-0cad69810.yml
@@ -1,5 +1,9 @@
 name: Azure Static Web Apps CI/CD
 
+permissions:
+  contents: read
+  pull-requests: write
+
 # Prevent multiple concurrent runs for the same branch/PR
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Potential fix for [https://github.com/Pace-Applied-Solutions/PacePublicShare/security/code-scanning/1](https://github.com/Pace-Applied-Solutions/PacePublicShare/security/code-scanning/1)

To fix the issue, we will add an explicit `permissions` block to the workflow file. This block will specify the exact permissions required for the workflow, reducing the risk of granting unintended access. For this workflow:
- The `contents: read` permission is necessary for accessing repository files during checkout.
- The `pull-requests: write` permission is needed for PR-related actions (e.g., closing pull requests).
- Other permissions will not be included unless explicitly required.

The `permissions` block will be added at the root of the workflow, applying to all jobs. This ensures consistency and avoids repetition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
